### PR TITLE
fix: correct semantic-release command in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Using default plugins: @semantic-release/commit-analyzer, @semantic-release/release-notes-generator, @semantic-release/github
-        # Adding @semantic-release/changelog and @semantic-release/git for changelog management
-        run: |
-          npx semantic-release \
-            @semantic-release/changelog \
-            @semantic-release/git
+        run: npx semantic-release


### PR DESCRIPTION
The semantic-release command was incorrectly passing plugins as command line arguments. This PR fixes it to use the plugins configured in .releaserc.json instead.