### PR TITLE
fix: update semantic-release changelog mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ changelog_file = "CHANGELOG.md"
 output_format = "md"
 # Don't show a generic message for first release
 mask_initial_release = false
-# Append to the existing changelog
-mode = "append"
+# Update the existing changelog
+mode = "update"


### PR DESCRIPTION
Fix the GitHub release workflow by changing the semantic-release changelog mode from 'append' to 'update' to match the allowed values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated changelog generation configuration to use a different mode for managing release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->