### PR TITLE
fix: update release workflow to handle protected main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Force correct release branch
+        run: |
+          git checkout -B ${{ github.ref_name }} ${{ github.sha }}
 
       - name: Python Semantic Release
         uses: python-semantic-release/python-semantic-release@v9.16.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: "github-actions"
+          git_committer_email: "actions@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,6 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v9.16.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Use GitHub Actions bot identity for release commits
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Force correct release branch
+        # Force branch creation at exact merge commit to ensure semantic-release has correct context
         run: |
           git checkout -B ${{ github.ref_name }} ${{ github.sha }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ commit_parser = "angular"
 logging_use_named_masks = false
 major_on_zero = true
 allow_zero_version = true
-repo_dir = "/Users/ismar/repos/unifi_assist"
 no_git_verify = false
 tag_format = "v{version}"
 
@@ -69,7 +68,6 @@ prerelease_token = "rc"
 prerelease = false
 
 [tool.semantic_release.changelog]
-changelog_file = ""
 exclude_commit_patterns = []
 mode = "init"
 insertion_flag = "<!-- version list -->"


### PR DESCRIPTION
- Add checkout at exact merge commit SHA
- Force checkout to correct branch name
- Add git committer info for releases
- Move changelog_file to correct config section

This should fix the semantic-release workflow by ensuring it runs on the correct branch context after PR merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced GitHub Actions release workflow for improved branch handling.
	- Removed specific local configuration entries from project configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->