### PR TITLE
fix: use root_options for semantic-release flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,6 @@ jobs:
           # Use GitHub Actions bot identity for release commits
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
+          # Don't commit/push to main (would fail branch protection)
+          # Instead just create the release and tag
+          root_options: "--no-commit --vcs-release"


### PR DESCRIPTION
- Change additional_options to root_options to properly pass CLI flags
- Add --no-commit and --vcs-release flags to avoid branch protection issues
- This should fix the release workflow by skipping the commit/push to main while still creating releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub release workflow configuration to improve release process compatibility with branch protection rules.
	- Modified semantic release action settings to prevent direct commits to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->