### PR TITLE
fix: move commit/push settings to workflow file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,9 @@ jobs:
           # Use GitHub Actions bot identity for release commits
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
+          # Don't commit/push to main (would fail branch protection)
+          commit: false
+          push: false
+          # Do create a release
+          tag: true
+          vcs_release: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ allow_zero_version = true
 no_git_verify = false
 tag_format = "{version}"
 version_toml = ["pyproject.toml:project.version"]
-commit = false  # Don't commit during release
-push = false   # Don't push commits
-tag = true     # Do create tags
 version_source = "tag"  # Use tags for version tracking
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
- Add commit/push/tag settings as action inputs in workflow
- Remove duplicate settings from pyproject.toml
- Keep other semantic-release config in pyproject.toml

This should fix the release workflow by:
1. Using action inputs to control commit/push behavior
2. Avoiding duplication between workflow and config
3. Still creating git tags and GitHub releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions release workflow configuration
	- Modified semantic release settings in project configuration

The changes refine the release process by adjusting workflow parameters and configuration options to better control version management and release tag creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->