### PR TITLE
chore: remove commit and push settings from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}  # Regular GITHUB_TOKEN is fine since we're not committing
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
-          commit: false
-          push: false
           tag: true
           vcs_release: true
           root_options: "-vv"


### PR DESCRIPTION
Removes unnecessary commit and push settings from the release workflow configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions release workflow configuration
  - Modified semantic release action parameters to allow automatic commits and repository pushes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->