### PR TITLE
chore: add back commit and push lines in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}  # Regular GITHUB_TOKEN is fine since we're not committing
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
+          commit: false
+          push: false
           tag: true
           vcs_release: true
           root_options: "-vv"


### PR DESCRIPTION
Restores previously removed commit and push configuration lines in the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions release workflow configuration to modify release process behavior
	- Adjusted semantic release action parameters to prevent automatic commits and pushes during release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->